### PR TITLE
API連携・チャットUI・Sidekiq/Redis本番対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "ruby-openai"
 # 非同期ジョブ用
 gem "sidekiq"
 
+gem "redis"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
+    redis (5.4.0)
+      redis-client (>= 0.22.0)
     redis-client (0.25.0)
       connection_pool
     regexp_parser (2.10.0)
@@ -368,6 +370,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)
+  redis
   rubocop-rails-omakase
   ruby-openai
   selenium-webdriver

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,0 +1,39 @@
+class ChatsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @chats = current_user.chats.includes(:ai_character).order(created_at: :desc)
+  end
+
+  def show
+    @chat = current_user.chats.find(params[:id])
+    @messages = @chat.messages.order(created_at: :asc)
+  end
+
+  def new
+    @chat = current_user.chats.build
+  end
+
+  def create
+    # デフォルトのAIキャラクターを使用
+    default_ai = current_user.ai_characters.first || create_default_ai
+    existing_chat = current_user.chats.find_by(ai_character_id: default_ai.id)
+
+    if existing_chat
+      redirect_to existing_chat, notice: '既存のチャットに戻りました。'
+    else
+      @chat = current_user.chats.build(ai_character: default_ai)
+      @chat.save
+      redirect_to @chat, notice: '新しいチャットが作成されました。'
+    end
+  end
+
+  private
+
+  def create_default_ai
+    current_user.ai_characters.create!(
+      name: "デフォルトAI",
+      personality: "あなたは親切で丁寧なアシスタントです。ユーザーの質問に分かりやすく答えてください。"
+    )
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,10 +6,10 @@ class MessagesController < ApplicationController
   end
 
   def create
-    @chat = current_user.chats.find(params[:chat_id])
+    @chat = Chat.find_or_create_by(id: params[:chat_id])
     @message = @chat.messages.create(message_params.merge(role: "user"))
-    
-    # Sidekiqジョブを実行
+    # ジョブを定義する
+    # perform_syncはジョブを非同期で実行するためsidekiqのメソッド
     GetAiResponse.perform_async(@message.chat_id)
 
     respond_to do |format|

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,25 @@
+class MessagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @message = Message.new
+  end
+
+  def create
+    @chat = current_user.chats.find(params[:chat_id])
+    @message = @chat.messages.create(message_params.merge(role: "user"))
+    
+    # Sidekiqジョブを実行
+    GetAiResponse.perform_async(@message.chat_id)
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content)
+  end
+end

--- a/app/helpers/chats_helper.rb
+++ b/app/helpers/chats_helper.rb
@@ -1,0 +1,2 @@
+module ChatsHelper
+end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,2 @@
+module MessagesHelper
+end

--- a/app/jobs/get_ai_response.rb
+++ b/app/jobs/get_ai_response.rb
@@ -1,0 +1,46 @@
+class GetAiResponse
+  include Sidekiq::Worker
+  RESPONSES_PER_MESSAGE = 1
+  MODEL_NAME = "gpt-4o-mini"
+  TEMPERATURE = 0.8
+
+  # ジョブを実行するメソッド
+  def perform(chat_id)
+    chat = Chat.find(chat_id)
+    call_openai(chat)
+  end
+
+  private
+
+  # チャットの応答を取得するメソッド
+  def call_openai(chat)
+    OpenAI::Client.new.chat(
+      parameters: {
+        model: MODEL_NAME,
+        messages: Message.for_openai(chat.messages.order(created_at: :asc)), # フォーマットをAPI用のフォーマットに変換する
+        temperature: TEMPERATURE,
+        stream: stream_proc(chat), # stream_procメソッドでストリーミングデータを処理
+        n: RESPONSES_PER_MESSAGE
+      }
+    )
+  end
+
+  # メッセージを作成するメソッド
+  def create_messages(chat)
+    Array.new(RESPONSES_PER_MESSAGE) do |i|
+      message = chat.messages.create(role: "assistant", content: "", response_number: i) # Messageに保存する
+      message.broadcast_created # 新しいメッセージが作成された後に、そのメッセージに対して broadcast_created メソッドが呼び出される
+      message
+    end
+  end
+
+  # ストリーミングデータを処理し、都度dbにupdateしていくメソッド
+  def stream_proc(chat)
+    messages = create_messages(chat)
+    proc do |chunk, _bytesize|
+      new_content = chunk.dig("choices", 0, "delta", "content")
+      message = messages.find { |m| m.response_number == chunk.dig("choices", 0, "index") }
+      message.update(content: message.content + new_content) if new_content
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,40 @@
 class Message < ApplicationRecord
-  enum role: { user: 0, ai: 1 }
+  include ActionView::RecordIdentifier
+  after_create_commit -> { broadcast_created }
+  after_update_commit -> { broadcast_updated }
+
+  enum role: { system: 0, assistant: 10, user: 20 }
   belongs_to :chat
   belongs_to :user, optional: true
+
+  # メッセージをOpenAIのAPI用のフォーマットに変換するメソッド(パフォーマンスを考慮し、プロンプト等のsystemメッセージは先頭に、それ以外は最新の50件を取得)
+  def self.for_openai(messages)
+    system_prompt = {
+      role: "system",
+      # contentはenvファイルから取得
+      content: ENV["OPENAI_SYSTEM_PROMPT"]
+    }
+    [system_prompt] + messages.map { |message| { role: message.role, content: message.content } }
+  end
+
+  # メッセージを作成したら、チャットのmessagesに追加するメソッド
+  def broadcast_created
+    # 指定したターゲット（DOM ID）に、新しいメッセージ（パーシャル）を後で追加（append）するという命令
+    broadcast_append_later_to(
+      "#{dom_id(chat)}_messages", # チャットのmessagesのDOM ID
+      partial: "messages/message", # パーシャルのパス
+      locals: { message: self, scroll_to: true }, # パーシャルに渡すローカル変数(メッセージとスクロールの設定)
+      target: "#{dom_id(chat)}_messages" # パーシャルのターゲット(チャットのmessagesのDOM ID)
+    )
+  end
+
+  def broadcast_updated
+    broadcast_append_to(
+      "#{dom_id(chat)}_messages",
+      partial: "messages/message",
+      locals: { message: self, scroll_to: true },
+      target: "#{dom_id(chat)}_messages"
+    )
+  end
+
 end 

--- a/app/views/chats/create.html.erb
+++ b/app/views/chats/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Chats#create</h1>
+  <p>Find me in app/views/chats/create.html.erb</p>
+</div>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,0 +1,28 @@
+<!-- app/views/chats/index.html.erb -->
+<div class="max-w-2xl mx-auto mt-8">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex-1 flex justify-center">
+      <h1 class="text-xl font-bold text-teal-700 text-center">FureAi トーク一覧</h1>
+    </div>
+    <%= link_to '＋ トーク新規作成', new_chat_path, class: "ml-2 px-3 py-2 bg-teal-500 text-white rounded-lg shadow hover:bg-teal-600 transition whitespace-nowrap text-sm" %>
+  </div>
+  <div class="bg-white rounded-lg shadow divide-y">
+    <% @chats.each do |chat| %>
+      <%= link_to chat_path(chat), class: "block" do %>
+        <div class="flex items-start px-4 py-3 hover:bg-teal-50 transition">
+          <!-- 画像は将来ここに <img ...> で -->
+          <div class="flex-shrink-0 w-12 h-12 rounded-full bg-gray-200 mr-4"></div>
+          <div class="flex-1 min-w-0">
+            <div class="flex justify-between items-center">
+              <span class="font-bold text-gray-900 text-base"><%= chat.ai_character.name %></span>
+              <span class="text-xs text-gray-400 ml-2"><%= l(chat.updated_at, format: :short) %></span>
+            </div>
+            <div class="text-gray-700 text-sm truncate">
+              <%= chat.messages.last&.content&.truncate(40) || 'まだ会話がありません' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/chats/new.html.erb
+++ b/app/views/chats/new.html.erb
@@ -1,0 +1,14 @@
+<div class="max-w-md mx-auto mt-8 p-6 bg-white rounded-lg shadow-md">
+  <h1 class="text-2xl font-bold text-gray-800 mb-4">新しいチャットを開始</h1>
+  
+  <p class="text-gray-600 mb-6">
+    デフォルトのAIアシスタントとチャットを開始します。
+  </p>
+
+  <%= form_with(model: @chat, local: true, class: "space-y-4") do |form| %>
+    <div class="flex justify-center">
+      <%= form.submit "チャット開始", 
+          class: "px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,0 +1,67 @@
+<!-- app/views/chats/show.html.erb -->
+<div class="min-h-screen bg-gray-50 flex flex-col items-stretch">
+  <!-- チャット全体のラッパー -->
+  <div class="w-full flex flex-col flex-1 pb-24 bg-transparent">
+    <!-- ヘッダー -->
+    <div class="flex items-center justify-between bg-teal-100 rounded-t-lg px-4 py-3 mb-2">
+      <!-- 戻るボタン -->
+      <%= link_to chats_path, class: "flex items-center text-teal-700 hover:text-teal-900" do %>
+        <svg class="w-6 h-6 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        <span class="hidden sm:inline">一覧へ</span>
+      <% end %>
+      <!-- AIキャラ名とアイコン -->
+      <div class="flex items-center">
+        <div class="w-10 h-10 rounded-full bg-gray-200 mr-3"></div>
+        <span class="font-bold text-lg text-teal-800"><%= @chat.ai_character.name %></span>
+      </div>
+      <!-- 設定マーク（モック） -->
+      <button class="text-teal-700 hover:text-teal-900 focus:outline-none">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round"
+            d="M12 6v6l4 2m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- 日付区切り -->
+    <div class="text-center text-xs text-gray-400 my-2">
+      <%= @messages.first&.created_at&.strftime('%Y.%m.%d') %>
+    </div>
+
+    <!-- メッセージ一覧 -->
+    <div class="space-y-4 flex-1 w-full px-2">
+      <% @messages.each do |message| %>
+        <% if message.user_id.present? %>
+          <!-- ユーザーメッセージ（右寄せ） -->
+          <div class="flex justify-end items-end">
+            <div class="bg-teal-400 text-white rounded-2xl px-4 py-3 max-w-xs text-base shadow">
+              <%= message.content %>
+            </div>
+            <span class="text-xs text-gray-400 ml-2"><%= message.created_at.strftime('%H:%M') %></span>
+          </div>
+        <% else %>
+          <!-- AIメッセージ（左寄せ） -->
+          <div class="flex items-end">
+            <div class="w-8 h-8 rounded-full bg-gray-200 mr-2"></div>
+            <div class="bg-gray-100 text-gray-800 rounded-2xl px-4 py-3 max-w-xs text-base shadow">
+              <%= message.content %>
+            </div>
+            <span class="text-xs text-gray-400 ml-2"><%= message.created_at.strftime('%H:%M') %></span>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <!-- 入力欄 -->
+    <div class="fixed bottom-0 left-0 w-full flex justify-center bg-transparent">
+      <div class="w-full bg-white border-t py-3 px-4 flex items-center">
+        <%= form_with(model: [@chat, Message.new], local: true, class: "flex w-full") do |form| %>
+          <%= form.text_field :content, placeholder: "メッセージを入力", class: "flex-1 rounded-full border px-4 py-2 mr-2 focus:outline-none" %>
+          <%= form.submit "送信", class: "bg-teal-500 text-white rounded-full px-4 py-2 hover:bg-teal-600 transition" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,4 +1,5 @@
 <!-- app/views/chats/show.html.erb -->
+<%= turbo_stream_from "#{dom_id(@chat)}_messages" %>
 <div class="min-h-screen bg-gray-50 flex flex-col items-stretch">
   <!-- チャット全体のラッパー -->
   <div class="w-full flex flex-col flex-1 pb-24 bg-transparent">
@@ -31,37 +32,11 @@
     </div>
 
     <!-- メッセージ一覧 -->
-    <div class="space-y-4 flex-1 w-full px-2">
-      <% @messages.each do |message| %>
-        <% if message.user_id.present? %>
-          <!-- ユーザーメッセージ（右寄せ） -->
-          <div class="flex justify-end items-end">
-            <div class="bg-teal-400 text-white rounded-2xl px-4 py-3 max-w-xs text-base shadow">
-              <%= message.content %>
-            </div>
-            <span class="text-xs text-gray-400 ml-2"><%= message.created_at.strftime('%H:%M') %></span>
-          </div>
-        <% else %>
-          <!-- AIメッセージ（左寄せ） -->
-          <div class="flex items-end">
-            <div class="w-8 h-8 rounded-full bg-gray-200 mr-2"></div>
-            <div class="bg-gray-100 text-gray-800 rounded-2xl px-4 py-3 max-w-xs text-base shadow">
-              <%= message.content %>
-            </div>
-            <span class="text-xs text-gray-400 ml-2"><%= message.created_at.strftime('%H:%M') %></span>
-          </div>
-        <% end %>
-      <% end %>
+    <div id="<%= dom_id(@chat) %>_messages" class="space-y-2 flex-1 w-full px-2 py-4 overflow-y-auto">
+      <%= render @messages %>
     </div>
 
     <!-- 入力欄 -->
-    <div class="fixed bottom-0 left-0 w-full flex justify-center bg-transparent">
-      <div class="w-full bg-white border-t py-3 px-4 flex items-center">
-        <%= form_with(model: [@chat, Message.new], local: true, class: "flex w-full") do |form| %>
-          <%= form.text_field :content, placeholder: "メッセージを入力", class: "flex-1 rounded-full border px-4 py-2 mr-2 focus:outline-none" %>
-          <%= form.submit "送信", class: "bg-teal-500 text-white rounded-full px-4 py-2 hover:bg-teal-600 transition" %>
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: "messages/form", locals: { chat: @chat } %>
   </div>
 </div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,0 +1,8 @@
+<%# メッセージを送信するフォーム %>
+<%# コマンド（Cmd）キーとEnterキーが同時に押されたときに、$eventオブジェクトのtargetプロパティ（イベントを発生させた要素）の親要素のフォームに対してrequestSubmit()メソッドを呼び出し、フォームを送信さる %>
+<%= turbo_frame_tag "#{dom_id(chat)}_message_form" do %>
+  <%= form_with(model: Message.new, url: chat_messages_path(chat), html: { class: "flex items-center w-full p-2 bg-white border-t" }) do |form| %>
+    <%= form.text_field :content, placeholder: "メッセージを入力", rows: 4, "x-on:keydown.cmd.enter" => "$event.target.form.requestSubmit();", class: "flex-1 rounded-full border px-4 py-2 mr-2 focus:outline-none" %>
+    <%= form.button '送信', type: :submit, class: "bg-sky-400 text-white rounded-full px-4 py-2 hover:bg-sky-500" %>
+  <% end %>
+<% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,24 @@
+<%# メッセージのDOM IDを取得し、そのメッセージを表示する %>
+<div id="<%= dom_id(message) %>_messages">
+  <div class="flex <%= message.user? ? 'justify-end' : 'justify-start' %> items-end w-full">
+    <% unless message.user? %>
+      <!-- アイコン（相手） -->
+      <div class="w-8 h-8 rounded-full bg-gray-200 mr-2 flex-shrink-0 flex items-center justify-center">
+        <!-- アイコン画像は任意で差し替え -->
+        <%= image_tag 'dog_icon.png', alt: 'AI', class: "w-8 h-8" if Rails.application.assets.find_asset('dog_icon.png') %>
+      </div>
+    <% end %>
+    <div class="<%= message.user? ? 'bg-teal-100 text-gray-800' : 'bg-gray-200 text-gray-800' %> rounded-2xl px-4 py-2 max-w-xs md:max-w-lg break-words shadow relative">
+      <%= message.content %>
+      <div class="text-xs text-gray-500 text-right mt-1">
+        <%= message.created_at.strftime('%H:%M') %>
+      </div>
+    </div>
+    <% if message.user? %>
+      <!-- アイコン（自分） -->
+      <div class="w-8 h-8 rounded-full bg-teal-100 ml-2 flex-shrink-0 flex items-center justify-center">
+        <%= image_tag 'user_icon.png', alt: 'You', class: "w-8 h-8" if Rails.application.assets.find_asset('user_icon.png') %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Messages#create</h1>
+  <p>Find me in app/views/messages/create.html.erb</p>
+</div>

--- a/app/views/messages/create.turbo_stream.erb
+++ b/app/views/messages/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%# メッセージを送信したら、チャットのmessagesに追加する %>
+<%= turbo_stream.append "#{dom_id(@message.chat)}_messages" do %>
+  <%= render "message", message: @message, scroll_to: true %>
+<% end %>
+<%= turbo_stream.replace "#{dom_id(@message.chat)}_message_form" do %>
+  <%= render "form", chat: @message.chat %>
+<% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Messages#new</h1>
+  <p>Find me in app/views/messages/new.html.erb</p>
+</div>

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  redis:
+    image: "redis:7.0-alpine"
+    volumes:
+      - redis_volume:/data
+    command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+
   web:
     build:
       context: .
@@ -27,12 +36,28 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      REDIS_URL: redis://redis:6379/0
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_started
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bash -c "bundle install && bundle exec sidekiq"
+    volumes:
+      - .:/myapp
+    depends_on:
+      - db
+      - redis
+
 volumes:
   bundle_data:
   postgresql_data:
   node_modules:
+  redis_volume:

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module FureAi
     #
     config.time_zone = "Asia/Tokyo"
     config.i18n.default_locale = :ja
+    config.active_job.queue_adapter = :sidekiq
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,7 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://redis:6379/1
+  channel_prefix: myapp_development
 
 test:
   adapter: test

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,3 +1,3 @@
 OpenAI.configure do |config|
-  config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+  config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN", "dummy_token")
 end 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://redis:6379' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://redis:6379' }
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,2 +1,5 @@
 ja:
   hello: "こんにちは"
+  time:
+    formats:
+      short: "%Y/%m/%d %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  mount Sidekiq::Web, at: '/sidekiq'
   get "messages/new"
   get "messages/create"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get "messages/new"
+  get "messages/create"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -16,4 +19,9 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
+
+  # チャット機能
+  resources :chats do
+    resources :messages, only: %i[new create]
+  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency: 10
+:queues:
+  - default

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class ChatsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get chats_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get chats_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get chats_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get chats_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class MessagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get messages_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get messages_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

OpenAI API連携、チャットUIのデザイン刷新、Sidekiq/Redis導入およびRender本番運用対応を行いました。

## 主な変更点

- チャット画面の吹き出し・左右分け・色分け・PC時の横幅調整、フォームデザイン変更
- systemロールのプロンプト柔らかく修正・for_openaiで昇順ソート・ENV対応
- Sidekiq/Redis導入・ジョブ追加・本番運用向け設定
- メッセージ送信・表示処理の修正およびTurbo Streamsテンプレート追加

## 対象コミット

- [65126da](https://github.com/taka292/fureai/commit/65126da) - ui: チャット画面の吹き出し・左右分け・色分け・PC時の横幅調整、フォームデザイン変更
- [dfebcba](https://github.com/taka292/fureai/commit/dfebcba) - feat: systemロールのプロンプト修正・for_openaiで昇順ソート・ENV対応
- [51ab646](https://github.com/taka292/fureai/commit/51ab646) - feat: Sidekiq/Redis導入・ジョブ追加・本番運用向け設定
- [88460bf](https://github.com/taka292/fureai/commit/88460bf) - fix: メッセージ送信・表示処理の修正およびTurbo Streamsテンプレート追加

