### PR TITLE
プロフィール編集機能追加・UIリファクタリング

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,41 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    user_params = params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    current_password = params[:user][:current_password]
+
+    # パスワード変更時のみcurrent_passwordのバリデーション
+    if user_params[:password].present?
+      if @user.valid_password?(current_password)
+        if @user.update(user_params)
+          redirect_to edit_profile_path, notice: 'プロフィールを更新しました'
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      else
+        @user.assign_attributes(user_params) # 入力値をフォームに反映
+        @user.errors.add(:current_password, "が正しくありません")
+        render :edit, status: :unprocessable_entity
+      end
+    else
+      # パスワード以外の更新はcurrent_password不要
+      if @user.update(user_params.except(:password, :password_confirmation))
+        redirect_to edit_profile_path, notice: 'プロフィールを更新しました'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password)
+  end
+end 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
   <div class="hero-content text-center">
     <div class="max-w-4xl">
       <!-- ロゴ・タイトル -->
-      <div class="mb-8">
+      <div class="mb-8 mt-20 pt-4">
         <h1 class="text-5xl md:text-7xl font-bold text-text mb-4">
           <span class="text-primary">Fure</span>Ai
         </h1>
@@ -173,21 +173,3 @@
     <p class="text-xs opacity-60 mt-4">© 2024 FureAi. All rights reserved.</p>
   </div>
 </footer>
-
-<!-- ログイン・ログアウトボタン（右上固定） -->
-<div class="fixed top-4 right-6 z-50 flex items-center gap-3">
-  <% if user_signed_in? %>
-    <div class="flex items-center gap-2  px-3 py-2">
-      <div class="w-6 h-6 bg-primary/20 rounded-full flex items-center justify-center">
-        <svg class="w-3 h-3 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-        </svg>
-      </div>
-      <span class="text-sm font-medium text-text"><%= current_user.name %></span>
-    </div>
-    <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-outline btn-sm" %>
-  <% else %>
-    <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary btn-sm" %>
-    <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline btn-sm" %>
-  <% end %>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,24 +21,7 @@
   </head>
 
   <body class="min-h-screen bg-base">
-    <!-- ヘッダー（チャット詳細ページ以外で表示） -->
-    <% unless controller_name == 'chats' && action_name == 'show' %>
-      <!-- ログイン・ログアウトボタン（右上固定） -->
-      <div class="fixed top-4 right-6 z-50 flex items-center gap-3">
-        <% if user_signed_in? %>
-          <div class="flex items-center gap-2 px-3 py-2">
-            <div class="w-6 h-6 bg-primary/20 rounded-full flex items-center justify-center">
-              <span class="material-symbols-outlined text-primary text-sm">person</span>
-            </div>
-            <span class="text-sm font-medium text-text"><%= current_user.name %></span>
-          </div>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-outline btn-sm" %>
-        <% else %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary btn-sm" %>
-          <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline btn-sm" %>
-        <% end %>
-      </div>
-    <% end %>
+    <%# ヘッダー部分を削除 %>
 
     <% flash.each do |key, value| %>
       <% color_class, icon_svg =
@@ -78,6 +61,11 @@
         <%= link_to root_path, class: "flex flex-col items-center text-primary" do %>
           <span class="material-symbols-outlined text-2xl">monitor_heart</span>
           <span class="text-xs">体調管理</span>
+        <% end %>
+        <!-- プロフィール -->
+        <%= link_to edit_profile_path, class: "flex flex-col items-center text-primary" do %>
+          <span class="material-symbols-outlined text-2xl">person</span>
+          <span class="text-xs">プロフィール</span>
         <% end %>
       </footer>
     <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,48 @@
+<div class="min-h-screen flex items-center justify-center bg-base-100 px-2">
+  <div class="card shadow-xl bg-white w-full max-w-md mx-auto">
+    <div class="card-body">
+      <h2 class="text-2xl font-bold text-primary text-center mb-2">
+        <span class="text-primary">プロフィール編集</span>
+      </h2>
+      <%= form_with model: @user, url: profile_path, method: :patch, local: true do |f| %>
+        <% if @user.errors.any? %>
+          <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+            <h3 class="text-red-800 font-medium mb-2">以下のエラーを修正してください：</h3>
+            <ul class="text-red-700 text-sm space-y-1">
+              <% @user.errors.full_messages.each do |message| %>
+                <li>• <%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <div class="form-control mb-4">
+          <%= f.label :name, "ユーザー名", class: "label font-semibold text-base-content" %>
+          <%= f.text_field :name, class: "input input-bordered w-full text-base-content placeholder:text-gray-400" %>
+        </div>
+        <div class="form-control mb-4">
+          <%= f.label :email, "メールアドレス", class: "label font-semibold text-base-content" %>
+          <%= f.email_field :email, class: "input input-bordered w-full text-base-content placeholder:text-gray-400" %>
+        </div>
+        <div class="form-control mb-4">
+          <%= f.label :password, "新しいパスワード", class: "label font-semibold text-base-content" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full text-base-content placeholder:text-gray-400" %>
+        </div>
+        <div class="form-control mb-4">
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "label font-semibold text-base-content" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full text-base-content placeholder:text-gray-400" %>
+        </div>
+        <div class="form-control mb-4">
+          <%= f.label :current_password, "現在のパスワード（変更時必須）", class: "label font-semibold text-base-content" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered w-full text-base-content placeholder:text-gray-400" %>
+        </div>
+        <div class="form-control mt-6">
+          <%= f.submit "保存", class: "btn btn-primary w-full text-white font-bold shadow-md hover:brightness-110 transition" %>
+        </div>
+      <% end %>
+      <div class="divider">または</div>
+      <div class="form-control mt-2">
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-outline btn-error w-full" %>
+      </div>
+    </div>
+  </div>
+</div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,6 @@ Rails.application.routes.draw do
 
   # AIキャラクター設定
   resources :ai_characters, only: %i[edit update]
+
+  resource :profile, only: [:edit, :update], controller: 'profiles'
 end


### PR DESCRIPTION
## 概要

プロフィール編集機能の追加と、UIリファクタリング（ヘッダー削除・ナビバーにプロフィールリンク追加）を行いました。

## 主な変更点

- プロフィール編集ページ（/profile）の新設
- ユーザー名・メールアドレス・パスワードの編集機能追加
- ナビゲーションバーに「プロフィール」リンクを追加
- ヘッダー（ユーザー名・ログアウトボタン等）の削除

## 対象コミット

- [b0acf6c](リンク) - feat: プロフィール編集機能を追加し、ユーザー情報の更新を可能にしました。また、ナビゲーションにプロフィールリンクを追加しました
