### PR TITLE
体調管理グラフの色・表示範囲・アイコン色の統一

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem "image_processing", "~> 1.2"
 # AWS S3 for Active Storage
 gem "aws-sdk-s3", require: false
 
+gem 'chartkick'
+gem 'groupdate'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -165,6 +166,8 @@ GEM
     ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    groupdate (6.7.0)
+      activesupport (>= 7.1)
     hashie (5.0.0)
     hpricot (0.8.6)
     html2slim (0.2.0)
@@ -456,10 +459,12 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  chartkick
   debug
   devise
   dotenv-rails
   erb_lint
+  groupdate
   html2slim
   image_processing (~> 1.2)
   jbuilder

--- a/README.md
+++ b/README.md
@@ -1,24 +1,202 @@
-# README
+# FureAi - その時のあなたに寄り添う、ふれあい AI
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+メンタル管理 × カスタマイズ可能な AI チャット。その日の調子を記録しつつ、その時のあなたに寄り添う、AI チャットにより、いつでも気軽に相談できる場所を提供します。
 
-Things you may want to cover:
+## 🌟 サービス概要
 
-* Ruby version
+FureAi は、24 時間いつでも気軽に相談できる AI チャット機能と、メンタル管理機能を組み合わせた Web アプリケーションです。
 
-* System dependencies
+### 想定ユーザー
 
-* Configuration
+- 仕事で大変な時に、気軽に相談しづらい会社員
+- 孤独を感じる人
+- 自分の気持ちを外に吐き出したい人
+- イライラやモヤモヤを感じやすい人
+- 自分のメンタルを管理したい人
 
-* Database creation
+### 解決する課題
 
-* Database initialization
+- 仕事で大変な時に、気軽に相談しづらい。また、24 時間いつでも相談しづらい
+- ChatGPT だと無機質な UI や返答で、人間のような温かみがない
+- 一般に出ている相談アプリだと高い
+- 自分の気分の変化を直感的に記録したい
+- 記録を習慣化するための仕組みがほしい
 
-* How to run the test suite
+## ✨ 主な機能
 
-* Services (job queues, cache servers, search engines, etc.)
+### 🤖 AI チャット機能
 
-* Deployment instructions
+- **カスタマイズ可能な AI キャラクター**: 相談者の性格や求めることに応じて返答をコントロール
+- **複数チャット**: チャットの新規作成で相談相手を分ける機能
+- **リアルタイム応答**: Turbo Streams による自然な会話体験
+- **背景カスタマイズ**: チャット画面の背景画像を設定可能
 
-* ...
+### 📊 メンタル管理機能
+
+- **日別記録**: 気持ちと体調を簡単に選択して記録
+- **グラフ表示**: 記録をグラフで見返して変化を可視化
+- **継続サポート**: リマインド・継続で経験値のような続く仕組み
+
+### 👤 ユーザー機能
+
+- **Google ログイン**: 簡単な認証で初回利用のハードルを下げる
+- **プロフィール設定**: 自分の推しやリラックス方法を設定
+- **画像管理**: アバター画像と背景画像のアップロード機能
+
+## 🛠 技術スタック
+
+### フロントエンド
+
+- **Rails 7.2.2** (Hotwire: Turbo / Stimulus)
+- **JavaScript** (esbuild)
+- **Tailwind CSS** + **daisyUI**
+- **Material Symbols** (アイコン)
+
+### バックエンド
+
+- **Ruby 3.2.8** (Rails)
+- **PostgreSQL** (データベース)
+- **Redis** (キャッシュ・セッション)
+
+### 認証・API
+
+- **Devise** + **OmniAuth** (Google ログイン対応)
+- **OpenAI API** (GPT-4o-mini)
+
+### インフラ・環境構築
+
+- **Docker** (開発環境)
+- **Render.com** (本番環境)
+- **Amazon S3** (画像ストレージ)
+
+### 非同期処理・UI 強化
+
+- **Sidekiq** + **Active Job** (非同期処理)
+- **ActiveStorage** (画像管理)
+- **Chartkick** (グラフ表示)
+
+## 🚀 セットアップ
+
+### 前提条件
+
+- Docker
+- Docker Compose
+
+### 開発環境の起動
+
+```bash
+# リポジトリをクローン
+git clone <repository-url>
+cd fureai
+
+# Docker環境で起動
+docker-compose up -d
+
+# データベースのセットアップ
+docker-compose exec web rails db:create
+docker-compose exec web rails db:migrate
+docker-compose exec web rails db:seed
+
+# アプリケーションにアクセス
+open http://localhost:3000
+```
+
+### 環境変数の設定
+
+`.env`ファイルを作成し、以下の環境変数を設定してください：
+
+```env
+# OpenAI API
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_SYSTEM_PROMPT=あなたは親切で丁寧なアシスタントです。
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+
+# AWS S3 (本番環境)
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=ap-northeast-1
+AWS_BUCKET=your_s3_bucket_name
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+```
+
+## 📁 プロジェクト構造
+
+```
+fureai/
+├── app/
+│   ├── controllers/          # コントローラー
+│   ├── models/              # モデル
+│   ├── views/               # ビュー
+│   ├── jobs/                # 非同期ジョブ
+│   └── javascript/          # JavaScript
+├── config/                  # 設定ファイル
+├── db/                      # データベース関連
+├── compose.yml              # Docker Compose設定
+└── Dockerfile.dev           # 開発用Dockerfile
+```
+
+## 🔧 主要な技術的工夫
+
+### 1. 非同期チャット処理
+
+- Sidekiq を使用した AI 応答の非同期処理
+- Turbo Streams によるリアルタイム更新
+- ストリーミング応答による自然な会話体験
+
+### 2. AI キャラクターのカスタマイズ
+
+- ユーザーごとの性格設定
+- プロンプトの動的生成
+- アバター画像の管理
+
+### 3. メンタル記録の可視化
+
+- 日別の記録機能
+- Chartkick によるグラフ表示
+- 継続的なメンタル管理のサポート
+
+### 4. 画像アップロード機能
+
+- ActiveStorage を使用した画像管理
+- アバター画像と背景画像の設定
+- S3 との連携
+
+## 🎨 UX/UI の特徴
+
+### 温かみのあるデザイン
+
+- メンタルケアサービスとして「温かみ」と「安心感」を重視
+- シンプルな構造で操作の迷いを最小化
+- 統一感のあるデザインシステム
+
+### ストレスフリーな操作
+
+- Turbo によるページ遷移の削減
+- 最小手順での設定変更
+- 直感的なナビゲーション
+
+## 🔮 今後の展望
+
+- **リマインダー機能**: メンタル記録の習慣化支援
+- **3 行日記機能**: より気軽な記録方法
+- **AI キャラクター共有**: ユーザー間でのキャラクター共有
+- **メンタル記録分析**: より詳細な自己理解のサポート
+
+## 📝 ライセンス
+
+© 2024 FureAi. All rights reserved.
+
+## 🤝 フィードバック
+
+実際に使用していただいたユーザーからの感想：
+
+- 「気分に応じて相談相手を変えられるのが良い」
+- 「メンタル記録で自分の変化が分かる」
+- 「もう少し応答の文言を人間っぽくしてほしい」
+
+改善提案やフィードバックは大歓迎です！

--- a/app/controllers/mental_conditions_controller.rb
+++ b/app/controllers/mental_conditions_controller.rb
@@ -1,0 +1,68 @@
+class MentalConditionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_mental_condition, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @mental_conditions = current_user.mental_conditions.order(recorded_at: :desc)
+    end_date = Time.current.in_time_zone('Asia/Tokyo').to_date
+    start_date = end_date - 6.days
+    @mental_chart = current_user.mental_conditions.where(recorded_at: start_date.beginning_of_day..end_date.end_of_day).group_by_day(:recorded_at, range: start_date..end_date).average(:mental_state)
+    @physical_chart = current_user.mental_conditions.where(recorded_at: start_date.beginning_of_day..end_date.end_of_day).group_by_day(:recorded_at, range: start_date..end_date).average(:physical_state)
+  end
+
+  def show
+  end
+
+  def new
+    if already_recorded_today?
+      redirect_to mental_conditions_path, alert: '本日分の記録はすでに登録されています' and return
+    end
+    @mental_condition = current_user.mental_conditions.new
+  end
+
+  def create
+    if already_recorded_today?
+      redirect_to mental_conditions_path, alert: '本日分の記録はすでに登録されています' and return
+    end
+    @mental_condition = current_user.mental_conditions.new(mental_condition_params)
+    @mental_condition.recorded_at = Time.current.in_time_zone('Asia/Tokyo').beginning_of_day
+    if @mental_condition.save
+      redirect_to mental_conditions_path, notice: '記録を保存しました'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @mental_condition.update(mental_condition_params)
+      redirect_to mental_conditions_path, notice: '記録を更新しました'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @mental_condition.destroy
+    redirect_to mental_conditions_path, notice: '記録を削除しました'
+  end
+
+  private
+
+  def set_mental_condition
+    @mental_condition = current_user.mental_conditions.find(params[:id])
+  end
+
+  def mental_condition_params
+    params.require(:mental_condition).permit(:mental_state, :physical_state)
+  end
+
+  def already_recorded_today?
+    today = Time.current.in_time_zone('Asia/Tokyo').to_date
+    current_user.mental_conditions.where(
+      recorded_at: today.beginning_of_day..today.end_of_day
+    ).exists?
+  end
+end

--- a/app/helpers/mental_conditions_helper.rb
+++ b/app/helpers/mental_conditions_helper.rb
@@ -1,0 +1,81 @@
+module MentalConditionsHelper
+  def mental_state_icon(state)
+    case state
+    when 'very_bad'
+      'favorite'  # 1個のハート
+    when 'bad'
+      'favorite_border'  # 2個のハート
+    when 'normal'
+      'favorite'  # 3個のハート
+    when 'good'
+      'favorite'  # 4個のハート
+    when 'very_good'
+      'favorite'  # 5個のハート
+    end
+  end
+
+  def physical_state_icon(state)
+    case state
+    when 'very_bad'
+      'sentiment_very_dissatisfied'  # とても不満
+    when 'bad'
+      'sentiment_dissatisfied'  # 不満
+    when 'normal'
+      'sentiment_neutral'  # 普通
+    when 'good'
+      'sentiment_satisfied'  # 満足
+    when 'very_good'
+      'sentiment_very_satisfied'  # とても満足
+    end
+  end
+
+  def mental_state_icons(state)
+    count = case state
+    when 'very_bad' then 1
+    when 'bad' then 2
+    when 'normal' then 3
+    when 'good' then 4
+    when 'very_good' then 5
+    end
+    (1..5).map do |i|
+      icon_class = i <= count ? 'text-red-500' : 'text-gray-300'
+      content_tag(:span, 'favorite', class: "material-symbols-outlined #{icon_class} text-2xl mr-0.5")
+    end.join.html_safe
+  end
+
+  def physical_state_icons(state)
+    count = case state
+    when 'very_bad' then 1
+    when 'bad' then 2
+    when 'normal' then 3
+    when 'good' then 4
+    when 'very_good' then 5
+    end
+    (1..5).map do |i|
+      icon_class = i <= count ? 'text-orange-400' : 'text-gray-300'
+      content_tag(:span, 'sentiment_satisfied', class: "material-symbols-outlined #{icon_class} text-2xl mr-0.5")
+    end.join.html_safe
+  end
+
+  def mental_state_to_number(state)
+    case state
+    when 'very_bad' then 1
+    when 'bad' then 2
+    when 'normal' then 3
+    when 'good' then 4
+    when 'very_good' then 5
+    else 0
+    end
+  end
+
+  def physical_state_to_number(state)
+    case state
+    when 'very_bad' then 1
+    when 'bad' then 2
+    when 'normal' then 3
+    when 'good' then 4
+    when 'very_good' then 5
+    else 0
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "chartkick/chart.js"

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import RatingController from "./rating_controller"
+application.register("rating", RatingController)

--- a/app/javascript/controllers/rating_controller.js
+++ b/app/javascript/controllers/rating_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.initializeRatings()
+  }
+
+  initializeRatings() {
+    this.setupRating("mental_state_icons", "mental_state_input", "mental")
+    this.setupRating("physical_state_icons", "physical_state_input", "physical")
+  }
+
+  setupRating(containerId, inputId, type) {
+    const container = document.getElementById(containerId)
+    const input = document.getElementById(inputId)
+    
+    if (container && input) {
+      container.addEventListener('click', (e) => {
+        if (e.target.dataset.index !== undefined) {
+          const index = parseInt(e.target.dataset.index)
+          this.updateRating(container, input, index, type)
+        }
+      })
+    }
+  }
+
+  updateRating(container, input, selectedIndex, type) {
+    const icons = container.querySelectorAll('span')
+    const states = ['very_bad', 'bad', 'normal', 'good', 'very_good']
+    
+    icons.forEach((icon, index) => {
+      if (index <= selectedIndex) {
+        icon.classList.remove('text-gray-300')
+        icon.classList.add(type === 'mental' ? 'text-red-500' : 'text-yellow-500')
+      } else {
+        icon.classList.remove(type === 'mental' ? 'text-red-500' : 'text-yellow-500')
+        icon.classList.add('text-gray-300')
+      }
+    })
+    
+    input.value = states[selectedIndex]
+  }
+} 

--- a/app/models/mental_condition.rb
+++ b/app/models/mental_condition.rb
@@ -1,0 +1,25 @@
+class MentalCondition < ApplicationRecord
+  belongs_to :user
+
+  enum mental_state: { very_bad: 0, bad: 1, normal: 2, good: 3, very_good: 4 }, _prefix: :mental
+  enum physical_state: { very_bad: 0, bad: 1, normal: 2, good: 3, very_good: 4 }, _prefix: :physical
+
+  validate :one_record_per_day_per_user_japan_time
+
+  private
+
+  def one_record_per_day_per_user_japan_time
+    return unless user && recorded_at
+    # 日本時間で日付を判定
+    jst_date = recorded_at.in_time_zone('Asia/Tokyo').to_date
+    exists = MentalCondition.where(user_id: user_id)
+      .where.not(id: id)
+      .where('recorded_at >= ? AND recorded_at < ?',
+        jst_date.beginning_of_day.in_time_zone('Asia/Tokyo'),
+        (jst_date + 1).beginning_of_day.in_time_zone('Asia/Tokyo')
+      ).exists?
+    if exists
+      errors.add(:base, '本日分の記録はすでに登録されています')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
          
   has_many :chats, dependent: :destroy
   has_many :ai_characters, dependent: :destroy
+  has_many :mental_conditions, dependent: :destroy
   has_many_attached :background_images
 
   def self.from_omniauth(auth)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -67,6 +67,10 @@
     <span class="material-symbols-outlined mr-2">chat</span>
     トークをみる
   <% end %>
+  <%= link_to new_mental_condition_path, class: "btn btn-primary btn-wide mt-3 font-bold shadow" do %>
+    <span class="material-symbols-outlined mr-2">monitor_heart</span>
+    体調を記録する
+  <% end %>
 </div>
 
 <!-- 日記カード -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
           <span class="text-xs">トーク一覧</span>
         <% end %>
         <!-- 体調管理 -->
-        <%= link_to root_path, class: "flex flex-col items-center text-primary" do %>
+        <%= link_to mental_conditions_path, class: "flex flex-col items-center text-primary" do %>
           <span class="material-symbols-outlined text-2xl">monitor_heart</span>
           <span class="text-xs">体調管理</span>
         <% end %>

--- a/app/views/mental_conditions/_form.html.erb
+++ b/app/views/mental_conditions/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: @mental_condition) do |f| %>
+  <div class="max-w-md mx-auto w-full">
+    <div class="bg-base-100 rounded-xl shadow p-6 mb-6 flex flex-col items-center">
+      <div class="w-14 h-14 bg-red-100 rounded-full flex items-center justify-center mb-2">
+        <span class="material-symbols-outlined text-red-500 text-4xl">favorite</span>
+      </div>
+      <%= f.label :mental_state, "こころ", class: "block text-lg font-bold text-text mb-1 text-center" %>
+      <p class="text-xs text-textSub mb-2 text-center">今日の気分をハートで選んでください</p>
+      <div class="flex space-x-1 my-2 justify-center">
+        <%= f.hidden_field :mental_state, id: "mental_state_input" %>
+        <div class="flex" id="mental_state_icons">
+          <% 5.times do |i| %>
+            <span class="material-symbols-outlined text-3xl cursor-pointer transition-colors
+              <%= i < mental_state_to_number(f.object.mental_state) ? 'text-red-500' : 'text-gray-300' %> hover:text-red-600"
+              data-index="<%= i %>" data-type="mental">
+              favorite
+            </span>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-base-100 rounded-xl shadow p-6 mb-6 flex flex-col items-center">
+      <div class="w-14 h-14 bg-orange-100 rounded-full flex items-center justify-center mb-2">
+        <span class="material-symbols-outlined text-orange-400 text-4xl">sentiment_satisfied</span>
+      </div>
+      <%= f.label :physical_state, "からだ", class: "block text-lg font-bold text-text mb-1 text-center" %>
+      <p class="text-xs text-textSub mb-2 text-center">今日の体の調子を選んでください</p>
+      <div class="flex space-x-1 my-2 justify-center">
+        <%= f.hidden_field :physical_state, id: "physical_state_input" %>
+        <div class="flex" id="physical_state_icons">
+          <% 5.times do |i| %>
+            <span class="material-symbols-outlined text-3xl cursor-pointer transition-colors
+              <%= i < physical_state_to_number(f.object.physical_state) ? 'text-orange-400' : 'text-gray-300' %> hover:text-orange-600"
+              data-index="<%= i %>" data-type="physical">
+              sentiment_satisfied
+            </span>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end">
+      <%= f.submit "保存", class: "btn btn-primary px-8 py-2 font-bold shadow w-full sm:w-auto" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/mental_conditions/edit.html.erb
+++ b/app/views/mental_conditions/edit.html.erb
@@ -1,0 +1,4 @@
+<div data-controller="rating">
+  <h2 class="text-2xl font-bold mb-6 text-text">こころとからだを編集する</h2>
+  <%= render 'form', mental_condition: @mental_condition %>
+</div> 

--- a/app/views/mental_conditions/index.html.erb
+++ b/app/views/mental_conditions/index.html.erb
@@ -1,0 +1,33 @@
+<h2 class="text-xl font-bold mb-4 text-text">コンディションの推移</h2>
+<div class="mb-8 overflow-x-auto w-full">
+  <%= area_chart [
+    {name: "こころ", data: @mental_chart},
+    {name: "からだ", data: @physical_chart}
+  ], height: '300px', library: {colors: ['#ef4444', '#fbbf24'], spanGaps: true} %>
+</div>
+
+<h2 class="text-xl font-bold mb-4 text-text">記録一覧</h2>
+<div class="space-y-4">
+  <% @mental_conditions.each do |condition| %>
+    <div class="p-4 rounded-xl shadow bg-base-100 flex flex-col md:flex-row md:items-center justify-between">
+      <div>
+        <div class="font-semibold text-text"><%= l condition.recorded_at, format: :long %></div>
+        <div class="mt-1">
+          <span class="text-red-500 font-semibold">こころ：</span>
+          <span class="flex items-center">
+            <%= mental_state_icons(condition.mental_state) %>
+          </span>
+        </div>
+        <div>
+          <span class="text-orange-400 font-semibold">からだ：</span>
+          <span class="flex items-center">
+            <%= physical_state_icons(condition.physical_state) %>
+          </span>
+        </div>
+      </div>
+      <div class="mt-2 md:mt-0 flex space-x-2">
+        <%= link_to '編集', edit_mental_condition_path(condition), class: 'btn btn-primary' %>
+        <%= link_to '削除', mental_condition_path(condition), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn bg-red-100 text-red-600 hover:bg-red-200' %>
+      </div>
+    </div>
+  <% end %> 

--- a/app/views/mental_conditions/new.html.erb
+++ b/app/views/mental_conditions/new.html.erb
@@ -1,0 +1,10 @@
+<div class="h-full w-full flex-1 flex flex-col justify-start items-center bg-base-100 overflow-auto py-4 pb-20" data-controller="rating">
+  <div class="flex flex-col items-center mb-8 w-full">
+    <h2 class="text-3xl font-bold text-text mb-2 text-center">こころとからだを記録する</h2>
+    <p class="text-base text-textSub text-center mb-1">今日の自分の気分と体調を、直感的に記録しましょう。</p>
+    <p class="text-xs text-gray-400 text-center">毎日1回だけ記録できます。自分の変化を見返すきっかけに。</p>
+  </div>
+  <div class="w-full max-w-md">
+    <%= render 'form', mental_condition: @mental_condition %>
+  </div>
+</div> 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require "groupdate"
 
 require "rails/all"
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,3 +22,16 @@ ja:
             avatar:
               content_type: "有効な画像ファイル（PNG、JPG、JPEG）を選択してください"
               size: "は5MB以下にしてください"
+  mental_condition:
+    mental_state:
+      very_bad: "とても悪い"
+      bad: "悪い"
+      normal: "普通"
+      good: "良い"
+      very_good: "とても良い"
+    physical_state:
+      very_bad: "体調最悪"
+      bad: "だるい"
+      normal: "普通"
+      good: "元気"
+      very_good: "絶好調"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,4 +40,6 @@ Rails.application.routes.draw do
   resources :ai_characters, only: %i[edit update]
 
   resource :profile, only: [ :edit, :update ], controller: "profiles"
+
+  resources :mental_conditions
 end

--- a/db/migrate/20250705063851_create_mental_conditions.rb
+++ b/db/migrate/20250705063851_create_mental_conditions.rb
@@ -1,0 +1,12 @@
+class CreateMentalConditions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mental_conditions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :mental_state
+      t.integer :physical_state
+      t.datetime :recorded_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_05_011916) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_05_063851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_05_011916) do
     t.index ["user_id"], name: "index_chats_on_user_id"
   end
 
+  create_table "mental_conditions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "mental_state"
+    t.integer "physical_state"
+    t.datetime "recorded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_mental_conditions_on_user_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.bigint "chat_id", null: false
     t.bigint "user_id"
@@ -93,6 +103,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_05_011916) do
   add_foreign_key "ai_characters", "users"
   add_foreign_key "chats", "ai_characters"
   add_foreign_key "chats", "users"
+  add_foreign_key "mental_conditions", "users"
   add_foreign_key "messages", "chats"
   add_foreign_key "messages", "users"
 end

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.16",
-    "tailwindcss": "^3.4.0",
+    "chart.js": "^4.5.0",
+    "chartkick": "^5.0.0",
     "daisyui": "^4.7.0",
-    "chartkick": "^5.0.0"
+    "tailwindcss": "^3.4.0"
   }
 }

--- a/test/controllers/mental_conditions_controller_test.rb
+++ b/test/controllers/mental_conditions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MentalConditionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/mental_conditions.yml
+++ b/test/fixtures/mental_conditions.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  mental_state: 1
+  physical_state: 1
+  recorded_at: 2025-07-05 15:38:51
+
+two:
+  user: two
+  mental_state: 1
+  physical_state: 1
+  recorded_at: 2025-07-05 15:38:51

--- a/test/models/mental_condition_test.rb
+++ b/test/models/mental_condition_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MentalConditionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,7 +299,7 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-chart.js@4:
+chart.js@4, chart.js@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.0.tgz#11a1ef6c4befc514b1b0b613ebac226c4ad2740b"
   integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==


### PR DESCRIPTION
## 概要

体調管理グラフの色を「こころ（赤）」「からだ（オレンジ）」のアイコン色に合わせ、表示・操作性を改善しました。

## 主な変更点

- グラフの色を「こころ：赤（#ef4444）」「からだ：オレンジ（#fbbf24）」に統一
- グラフの初期表示を直近1週間分に限定し、横スクロールで全期間閲覧可能に
- アイコン色とグラフ色の統一

## 対象コミット

- b4fffb0 - feat: メンタル状態と身体状態を記録する機能を追加
