### PR TITLE
fix: チャット画面の不具合修正と新機能追加

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("chat-scroll", ChatScrollController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import MessageAvatarController from "./message_avatar_controller"
+application.register("message-avatar", MessageAvatarController)
+
 import RatingController from "./rating_controller"
-application.register("rating", RatingController)
+application.register("rating", RatingController)x

--- a/app/javascript/controllers/message_avatar_controller.js
+++ b/app/javascript/controllers/message_avatar_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["avatar"]
+
+  connect() {
+    this.fixAvatarUrl()
+  }
+
+  fixAvatarUrl() {
+    this.avatarTargets.forEach(avatar => {
+      if (avatar.src && avatar.src.includes('example.org')) {
+        avatar.src = avatar.src.replace('http://example.org', window.location.origin)
+      }
+    })
+  }
+} 

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -12,7 +12,7 @@
         <div class="flex items-start px-4 py-3 hover:bg-teal-50 transition">
           <!-- アバター画像 -->
           <% if chat.ai_character.avatar.attached? %>
-            <%= image_tag rails_blob_url(chat.ai_character.avatar), class: "flex-shrink-0 w-12 h-12 rounded-full object-cover mr-4" %>
+            <%= image_tag chat.ai_character.avatar, class: "flex-shrink-0 w-12 h-12 rounded-full object-cover mr-4" %>
           <% else %>
             <div class="flex-shrink-0 w-12 h-12 rounded-full bg-gray-200 mr-4 flex items-center justify-center">
               <span class="material-symbols-outlined text-gray-400">person</span>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -20,7 +20,7 @@
       <!-- AIキャラ名とアイコン -->
       <div class="flex items-center">
         <% if @chat.ai_character.avatar.attached? %>
-          <%= image_tag rails_blob_url(@chat.ai_character.avatar), class: "w-16 h-16 rounded-full object-cover mr-3" %>
+          <%= image_tag @chat.ai_character.avatar, class: "w-16 h-16 rounded-full object-cover mr-3" %>
         <% else %>
           <div class="w-16 h-16 rounded-full bg-gray-200 mr-3 flex items-center justify-center">
             <span class="material-symbols-outlined text-gray-400 text-xl">person</span>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,11 +1,11 @@
 <%# メッセージのDOM IDを取得し、そのメッセージを表示する %>
-<div id="<%= dom_id(message) %>_messages" class="min-h-[60px]" <%= 'data-scroll-to="true"'.html_safe if local_assigns[:scroll_to] %>>
+<div id="<%= dom_id(message) %>_messages" class="min-h-[60px]" <%= 'data-scroll-to="true"'.html_safe if local_assigns[:scroll_to] %> data-controller="message-avatar">
   <div class="flex <%= message.user? ? "justify-end" : "justify-start" %> items-end w-full">
     <% unless message.user? %>
       <!-- アイコン（相手） -->
       <% ai_character = message.chat.ai_character %>
       <% if ai_character&.avatar&.attached? %>
-        <%= image_tag rails_blob_url(ai_character.avatar), class: "w-12 h-12 rounded-full object-cover mr-2 flex-shrink-0", alt: ai_character.name %>
+        <%= image_tag ai_character.avatar, class: "w-12 h-12 rounded-full object-cover mr-2 flex-shrink-0", alt: ai_character.name, data: { message_avatar_target: "avatar" } %>
       <% else %>
         <div class="w-12 h-12 rounded-full bg-gray-200 mr-2 flex-shrink-0 flex items-center justify-center">
           <span class="material-symbols-outlined text-gray-400 text-sm">person</span>


### PR DESCRIPTION
## 概要

チャット画面の複数の不具合を修正し、新規ユーザー向けのデフォルトAIキャラクター機能を追加しました。

## 主な変更点

- スマホのトーク画面のメッセージ送信部分が見切れないように固定
- チャット作成時のプロンプトのデフォルト値を設定
- 新規登録時にノーマル、聞き上手、アドバイス上手のデフォルトAI3つを自動作成
- AIからのメッセージ受信時に背景画面が動く不具合を修正
- 非同期メッセージ表示時のアバター画像表示問題を修正
- メッセージ送信後の自動スクロール機能を追加

## 対象コミット

- メッセージ送信フォームの固定位置配置
- メッセージ一覧の高さ固定によるレイアウトシフト防止
- ユーザー新規登録時のデフォルトAIキャラクター自動作成
- 非同期メッセージ表示時の画像URL動的修正
- JavaScriptコントローラーによる自動スクロール機能実装

## 技術的な変更点

- メッセージ送信フォームを位置に配置
- メッセージ一覧コンテナにの固定高さを設定
- ユーザーモデルにコールバックを追加
- 即座実行関数による画像URLの動的修正
- Stimulusコントローラーによる自動スクロール機能