### PR TITLE
日記機能の追加

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,0 +1,66 @@
+class DiariesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_diary, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @diaries = current_user.diaries.order(recorded_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @diary = current_user.diaries.new
+    if params[:date]
+      @diary.recorded_at = Date.parse(params[:date]).in_time_zone("Asia/Tokyo").beginning_of_day
+    else
+      @diary.recorded_at = Time.current.in_time_zone("Asia/Tokyo")
+    end
+  end
+
+  def create
+    @diary = current_user.diaries.new(diary_params)
+    if params[:diary][:recorded_at].present?
+      date = Date.parse(params[:diary][:recorded_at])
+      @diary.recorded_at = date.in_time_zone("Asia/Tokyo").beginning_of_day
+    else
+      @diary.recorded_at = Time.current.in_time_zone("Asia/Tokyo")
+    end
+    if @diary.save
+      redirect_to mental_conditions_path, notice: "日記を保存しました"
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    @diary.assign_attributes(diary_params)
+    if params[:diary][:recorded_at].present?
+      date = Date.parse(params[:diary][:recorded_at])
+      @diary.recorded_at = date.in_time_zone("Asia/Tokyo").beginning_of_day
+    end
+    if @diary.save
+      redirect_to mental_conditions_path, notice: "日記を更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @diary.destroy
+    redirect_to mental_conditions_path, notice: "日記を削除しました"
+  end
+
+  private
+
+  def set_diary
+    @diary = current_user.diaries.find(params[:id])
+  end
+
+  def diary_params
+    params.require(:diary).permit(:content, :recorded_at)
+  end
+end

--- a/app/controllers/mental_conditions_controller.rb
+++ b/app/controllers/mental_conditions_controller.rb
@@ -4,6 +4,7 @@ class MentalConditionsController < ApplicationController
 
   def index
     @mental_conditions = current_user.mental_conditions.order(recorded_at: :desc)
+    @diaries = current_user.diaries.order(recorded_at: :desc)
     @already_recorded_today = already_recorded_today?
     end_date = Time.current.in_time_zone("Asia/Tokyo").to_date
     start_date = end_date - 6.days
@@ -21,6 +22,22 @@ class MentalConditionsController < ApplicationController
       .group_by_day(:recorded_at, range: start_date..end_date, format: "%m/%d", time_zone: "Asia/Tokyo")
       .average(:physical_state)
       .transform_values { |v| v.nil? ? nil : v + 1 }
+
+    # 日付ごとにコンディションと日記をグループ化
+    @records_by_date = {}
+    @mental_conditions.each do |condition|
+      next unless condition.recorded_at
+      date_key = condition.recorded_at.in_time_zone("Asia/Tokyo").to_date
+      @records_by_date[date_key] ||= { condition: nil, diary: nil }
+      @records_by_date[date_key][:condition] = condition
+    end
+    @diaries.each do |diary|
+      next unless diary.recorded_at
+      date_key = diary.recorded_at.in_time_zone("Asia/Tokyo").to_date
+      @records_by_date[date_key] ||= { condition: nil, diary: nil }
+      @records_by_date[date_key][:diary] = diary
+    end
+    @records_by_date = @records_by_date.sort_by { |date, _| date }.reverse.to_h
   end
 
   def show

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,0 +1,23 @@
+class Diary < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true
+  validate :one_diary_per_day_per_user_japan_time
+
+  private
+
+  def one_diary_per_day_per_user_japan_time
+    return unless user && recorded_at
+    # 日本時間で日付を判定
+    jst_date = recorded_at.in_time_zone("Asia/Tokyo").to_date
+    exists = Diary.where(user_id: user_id)
+      .where.not(id: id)
+      .where("recorded_at >= ? AND recorded_at < ?",
+        jst_date.beginning_of_day.in_time_zone("Asia/Tokyo"),
+        (jst_date + 1).beginning_of_day.in_time_zone("Asia/Tokyo")
+      ).exists?
+    if exists
+      errors.add(:base, "この日の日記はすでに登録されています")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :chats, dependent: :destroy
   has_many :ai_characters, dependent: :destroy
   has_many :mental_conditions, dependent: :destroy
+  has_many :diaries, dependent: :destroy
   has_many_attached :background_images
 
   after_create :create_default_ai_characters

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with(model: diary) do |f| %>
+  <div class="max-w-md mx-auto w-full">
+    <div class="bg-base-100 rounded-xl shadow p-6 mb-6">
+      <%= f.label :recorded_at, "日付", class: "block text-lg font-bold text-text mb-2" %>
+      <%= f.date_field :recorded_at, value: diary.recorded_at&.strftime("%Y-%m-%d"), class: "input input-bordered w-full" %>
+      <% if diary.errors[:recorded_at].any? %>
+        <p class="text-red-500 text-sm mt-1"><%= diary.errors[:recorded_at].first %></p>
+      <% end %>
+    </div>
+
+    <div class="bg-base-100 rounded-xl shadow p-6 mb-6">
+      <%= f.label :content, "日記", class: "block text-lg font-bold text-text mb-2" %>
+      <%= f.text_area :content, rows: 10, placeholder: "今日の出来事や気持ちを自由に書いてください", class: "textarea textarea-bordered w-full" %>
+      <% if diary.errors[:content].any? %>
+        <p class="text-red-500 text-sm mt-1"><%= diary.errors[:content].first %></p>
+      <% end %>
+      <% if diary.errors[:base].any? %>
+        <p class="text-red-500 text-sm mt-1"><%= diary.errors[:base].first %></p>
+      <% end %>
+    </div>
+
+    <div class="flex justify-end space-x-2">
+      <%= link_to 'キャンセル', mental_conditions_path, class: "btn btn-ghost px-8 py-2 font-bold shadow" %>
+      <%= f.submit "保存", class: "btn btn-primary px-8 py-2 font-bold shadow" %>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="h-full w-full flex-1 flex flex-col justify-start items-center bg-base-100 overflow-auto py-4 pb-20">
+  <div class="flex flex-col items-center mb-8 w-full">
+    <h2 class="text-3xl font-bold text-text mb-2 text-center">日記を編集</h2>
+    <p class="text-base text-textSub text-center mb-1">日記の内容を編集できます。</p>
+  </div>
+  <div class="w-full max-w-md">
+    <%= render 'form', diary: @diary %>
+  </div>
+</div>
+
+

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,0 +1,12 @@
+<div class="h-full w-full flex-1 flex flex-col justify-start items-center bg-base-100 overflow-auto py-4 pb-20">
+  <div class="flex flex-col items-center mb-8 w-full">
+    <h2 class="text-3xl font-bold text-text mb-2 text-center">日記を書く</h2>
+    <p class="text-base text-textSub text-center mb-1">今日の出来事や気持ちを記録しましょう。</p>
+    <p class="text-xs text-gray-400 text-center">過去の日付にも日記を付けられます。</p>
+  </div>
+  <div class="w-full max-w-md">
+    <%= render 'form', diary: @diary %>
+  </div>
+</div>
+
+

--- a/app/views/mental_conditions/index.html.erb
+++ b/app/views/mental_conditions/index.html.erb
@@ -1,10 +1,13 @@
 <div class="flex items-center justify-between mb-4">
   <h2 class="text-xl font-bold text-text">コンディションの推移</h2>
-  <% if @already_recorded_today %>
-    <span class="text-xs text-textSub">本日分は記録済み</span>
-  <% else %>
-    <%= link_to '今日の記録をする', new_mental_condition_path, class: 'btn btn-primary btn-sm' %>
-  <% end %>
+  <div class="flex items-center space-x-2">
+    <%= link_to '日記する', new_diary_path, class: 'btn btn-secondary btn-sm' %>
+    <% if @already_recorded_today %>
+      <span class="text-xs text-textSub">本日分は記録済み</span>
+    <% else %>
+      <%= link_to '今日の記録をする', new_mental_condition_path, class: 'btn btn-primary btn-sm' %>
+    <% end %>
+  </div>
 </div>
 <div class="mb-8 overflow-x-auto w-full">
   <%= area_chart [
@@ -24,27 +27,47 @@
 
 <h2 class="text-xl font-bold mb-4 text-text">記録一覧</h2>
 <div class="space-y-4">
-  <% @mental_conditions.each do |condition| %>
-    <div class="p-4 rounded-xl shadow bg-base-100 flex flex-col md:flex-row md:items-center justify-between">
-      <div>
-        <div class="font-semibold text-text"><%= l condition.recorded_at, format: :default %></div>
-        <div class="mt-1">
-          <span class="text-red-500 font-semibold">こころ：</span>
-          <span class="flex items-center">
-            <%= mental_state_icons(condition.mental_state) %>
-          </span>
+  <% @records_by_date.each do |date, records| %>
+    <div class="p-4 rounded-xl shadow bg-base-100">
+      <div class="font-semibold text-text mb-3"><%= l date, format: :default %></div>
+      
+      <% if records[:condition] %>
+        <div class="mb-3 pb-3 border-b border-gray-200">
+          <div class="flex flex-col md:flex-row md:items-center justify-between">
+            <div class="flex-1">
+              <div class="mt-1">
+                <span class="text-red-500 font-semibold">こころ：</span>
+                <span class="flex items-center">
+                  <%= mental_state_icons(records[:condition].mental_state) %>
+                </span>
+              </div>
+              <div>
+                <span class="text-orange-400 font-semibold">からだ：</span>
+                <span class="flex items-center">
+                  <%= physical_state_icons(records[:condition].physical_state) %>
+                </span>
+              </div>
+            </div>
+            <div class="mt-2 md:mt-0 flex space-x-2">
+              <%= link_to '編集', edit_mental_condition_path(records[:condition]), class: 'btn btn-primary btn-sm' %>
+              <%= link_to '削除', mental_condition_path(records[:condition]), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn bg-red-100 text-red-600 hover:bg-red-200 btn-sm' %>
+            </div>
+          </div>
         </div>
-        <div>
-          <span class="text-orange-400 font-semibold">からだ：</span>
-          <span class="flex items-center">
-            <%= physical_state_icons(condition.physical_state) %>
-          </span>
+      <% end %>
+
+      <% if records[:diary] %>
+        <div class="flex flex-col md:flex-row md:items-start justify-between">
+          <div class="flex-1">
+            <div class="text-sm text-textSub mb-1">日記</div>
+            <div class="text-text whitespace-pre-wrap"><%= records[:diary].content %></div>
+          </div>
+          <div class="mt-2 md:mt-0 flex space-x-2">
+            <%= link_to '編集', edit_diary_path(records[:diary]), class: 'btn btn-primary btn-sm' %>
+            <%= link_to '削除', diary_path(records[:diary]), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn bg-red-100 text-red-600 hover:bg-red-200 btn-sm' %>
+          </div>
         </div>
-      </div>
-      <div class="mt-2 md:mt-0 flex space-x-2">
-        <%= link_to '編集', edit_mental_condition_path(condition), class: 'btn btn-primary' %>
-        <%= link_to '削除', mental_condition_path(condition), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn bg-red-100 text-red-600 hover:bg-red-200' %>
-      </div>
+      <% end %>
     </div>
   <% end %> 
 </div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,8 @@ Rails.application.routes.draw do
 
   resource :profile, only: [ :edit, :update ], controller: "profiles"
 
-      resources :mental_conditions
+  resources :mental_conditions
+  resources :diaries
 
     namespace :api do
       post "ai_response", to: "ai_responses#create"

--- a/db/migrate/20251130134120_create_diaries.rb
+++ b/db/migrate/20251130134120_create_diaries.rb
@@ -1,0 +1,11 @@
+class CreateDiaries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :diaries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :content, null: false
+      t.datetime :recorded_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_05_063851) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_30_134120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_05_063851) do
     t.index ["user_id"], name: "index_chats_on_user_id"
   end
 
+  create_table "diaries", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.datetime "recorded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_diaries_on_user_id"
+  end
+
   create_table "mental_conditions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "mental_state"
@@ -103,6 +112,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_05_063851) do
   add_foreign_key "ai_characters", "users"
   add_foreign_key "chats", "ai_characters"
   add_foreign_key "chats", "users"
+  add_foreign_key "diaries", "users"
   add_foreign_key "mental_conditions", "users"
   add_foreign_key "messages", "chats"
   add_foreign_key "messages", "users"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `Diary` model and full CRUD (with JST one-per-day validation) and integrates diaries into the mental conditions index, including routes, views, and migration.
> 
> - **Backend**:
>   - **Model**: Introduce `Diary` with `belongs_to :user`, `content` validation, and JST one-per-day custom validation.
>   - **Controller**: New `DiariesController` with `index/show/new/create/edit/update/destroy`; sets `recorded_at` in JST.
>   - **Integration**: `MentalConditionsController#index` now loads diaries and groups records by date (`@records_by_date`) combining conditions and diaries.
>   - **User Assoc/Routes**: Add `has_many :diaries` to `User`; register `resources :diaries` and `resources :mental_conditions` at top level.
>   - **DB**: Migration creating `diaries` table (`user_id`, `content`, `recorded_at`) and schema updates.
> - **Frontend**:
>   - **Views**: Add `diaries/new`, `diaries/edit`, and shared `_form` with date and content inputs; add diary actions (edit/delete) in records list.
>   - **UI Update**: On conditions index, add "日記する" button and render per-date combined entries for condition and diary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56364e479845a85537d7222a26470a64d742ec2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diary feature allowing users to create, view, edit, and delete diary entries
  * Enforced one diary entry per day per user
  * Updated main interface to display diaries and mental conditions organized by date
  * Added diary creation link to the header

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->